### PR TITLE
Enable stricter mypy type checking rules

### DIFF
--- a/noxfile.py.jinja
+++ b/noxfile.py.jinja
@@ -61,6 +61,10 @@ def mypy(session):
         "mypy",
         "--warn-unused-ignores",
         "--ignore-missing-imports",
+        "--disallow-untyped-defs",
+        "--disallow-incomplete-defs",
+        "--disallow-any-explicit",
+        "--disallow-any-generics",
         "src/",
     )
 


### PR DESCRIPTION
This change enhances the mypy configuration in the noxfile to enforce stricter type checking standards across the codebase.

**Summary**
Four additional mypy flags have been added to the type checking session to improve code quality and type safety:

- `--disallow-untyped-defs`: Requires all function definitions to have type annotations
- `--disallow-incomplete-defs`: Disallows functions with incomplete type information
- `--disallow-any-explicit`: Prevents explicit use of `Any` type
- `--disallow-any-generics`: Disallows generic types without explicit type parameters

These stricter rules will help catch type-related issues earlier and encourage more comprehensive type annotations throughout the codebase.

https://claude.ai/code/session_01JKMPKc42thFvzVPeBTCUna