### PR TITLE
Modernize Python versions and adopt stolid for linting

### DIFF
--- a/.github/workflows/pr-main.yml.jinja
+++ b/.github/workflows/pr-main.yml.jinja
@@ -7,12 +7,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python: "3.11", os: ubuntu-latest, check: "tests-3.11" }
           - { python: "3.12", os: ubuntu-latest, check: "tests-3.12" }
-          - { python: "3.12", os: ubuntu-latest, check: "lint" }
-          - { python: "3.12", os: ubuntu-latest, check: "docs" }
-          - { python: "3.12", os: ubuntu-latest, check: "mypy" }
-          - { python: "3.12", os: ubuntu-latest, check: "build" }
+          - { python: "3.13", os: ubuntu-latest, check: "tests-3.13" }
+          - { python: "3.14", os: ubuntu-latest, check: "tests-3.14" }
+          - { python: "3.14", os: ubuntu-latest, check: "lint" }
+          - { python: "3.14", os: ubuntu-latest, check: "docs" }
+          - { python: "3.14", os: ubuntu-latest, check: "mypy" }
+          - { python: "3.14", os: ubuntu-latest, check: "build" }
+          - { python: "3.13", os: ubuntu-latest, check: "dry_release" }
     name: ${{ matrix.check }} on Python ${{ matrix.python }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -33,7 +33,7 @@ jobs:
         run: python -m build
 
       - name: Upload built packages
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: built-packages
           path: ./dist/
@@ -47,9 +47,9 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts directories # goes to current working directory
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@v4
 
       - name: publish
-        uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          packages_dir: built-packages/
+          packages-dir: built-packages/

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -16,7 +16,7 @@ nox
 Run specific sessions:
 ```bash
 nox -s tests    # Run tests with coverage
-nox -s lint     # Run black and flake8
+nox -s lint     # Run black and stolid
 nox -s mypy     # Run type checking
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -251,8 +251,9 @@ Detailed Python Ecosystem Stack
 
   * `black`_
     for automatically fixable errors.
-  * `flake8`_
-    for other issues.
+  * `stolid`_
+    for enforcing the standard-template conventions
+    (it runs `flake8`_ and then its own cross-file checks).
   * `mypy`_
     for type checking.
 * For documentation:
@@ -273,6 +274,7 @@ Detailed Python Ecosystem Stack
 .. _hamcrest: https://pyhamcrest.readthedocs.io/en/stable/
 .. _black: https://black.readthedocs.io/en/stable/
 .. _flake8: https://flake8.pycqa.org/en/latest/
+.. _stolid: https://github.com/moshez/stolid
 .. _coverage: https://coverage.readthedocs.io/en/stable/
 .. _mypy: https://mypy.readthedocs.io/en/stable/
 .. _pyproject.toml: https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/

--- a/noxfile.py.jinja
+++ b/noxfile.py.jinja
@@ -1,12 +1,55 @@
 import functools
 import os
+import re
+import urllib.request
 
 import nox
 
 nox.options.envdir = "build/nox"
-nox.options.sessions = ["lint", "tests", "mypy", "docs", "build"]
+nox.options.sessions = ["lint", "tests", "mypy", "docs", "dry_release"]
 
-VERSIONS = ["3.11", "3.12"]
+VERSIONS = ["3.12", "3.13", "3.14"]
+
+PUBLISH_ACTION = "pypa/gh-action-pypi-publish"
+# The interpreter the publish action uploads with (its Docker base image).
+# Committed so nox can select it before the session runs, but verified
+# against the pinned action at runtime (_verify_publish_python) so it cannot
+# silently drift. The dry_release row in pr-main.yml must use this version
+# too, or nox's --python filter fails the job.
+PUBLISH_PYTHON = "3.13"
+
+
+def _publish_action_sha():
+    workflow = os.path.join(
+        os.path.dirname(__file__), ".github", "workflows", "release.yml"
+    )
+    with open(workflow, encoding="utf-8") as stream:
+        pattern = re.escape(PUBLISH_ACTION) + r"@([0-9a-f]{40})"
+        match = re.search(pattern, stream.read())
+    return match.group(1)
+
+
+def _publish_action_file(sha, path):
+    url = f"https://raw.githubusercontent.com/{PUBLISH_ACTION}/{sha}/{path}"
+    with urllib.request.urlopen(url) as response:
+        return response.read().decode()
+
+
+def _verify_publish_python(sha):
+    dockerfile = _publish_action_file(sha, "Dockerfile")
+    match = re.search(r"^FROM python:(\d+\.\d+)", dockerfile, re.MULTILINE)
+    found = match.group(1) if match else None
+    if found != PUBLISH_PYTHON:
+        raise ValueError(
+            f"{PUBLISH_ACTION}@{sha} uploads on Python {found}, but "
+            f"PUBLISH_PYTHON is {PUBLISH_PYTHON}. Update PUBLISH_PYTHON and "
+            "the dry_release row in pr-main.yml to match the pinned action."
+        )
+
+
+def _publish_twine_requirement(sha):
+    runtime = _publish_action_file(sha, "requirements/runtime.txt")
+    return re.search(r"^twine==\S+", runtime, re.MULTILINE).group(0)
 
 
 @nox.session(python=VERSIONS)
@@ -43,28 +86,40 @@ def build(session):
     session.run("python", "-m", "build", "--wheel")
 
 
+@nox.session(python=PUBLISH_PYTHON)
+def dry_release(session):
+    """Build sdist and wheel and validate them with the publish toolchain.
+
+    Runs on the same Python and twine the pinned publish action uploads
+    with, so anything the real upload would reject fails here first.
+    """
+    sha = _publish_action_sha()
+    _verify_publish_python(sha)
+    output = os.path.abspath(os.path.join(session.create_tmp(), "dist"))
+    session.install("build", _publish_twine_requirement(sha))
+    session.run("python", "-m", "build", "--outdir", output)
+    files = sorted(os.path.join(output, name) for name in os.listdir(output))
+    session.run("twine", "check", "--strict", *files)
+
+
 @nox.session(python=VERSIONS[-1])
 def lint(session):
     files = ["src/", "noxfile.py"]
     session.install("-r", "requirements-lint.txt")
     session.install("-e", ".")
     session.run("black", "--check", "--diff", *files)
-    black_compat = ["--max-line-length=88", "--ignore=E203,E503"]
-    session.run("flake8", *black_compat, "src/")
+    session.run("python", "-m", "stolid", "src/")
 
 
 @nox.session(python=VERSIONS[-1])
 def mypy(session):
     session.install("-r", "requirements-mypy.txt")
+    session.install("-r", "requirements-tests.txt")
     session.install("-e", ".")
     session.run(
         "mypy",
-        "--warn-unused-ignores",
-        "--ignore-missing-imports",
-        "--disallow-untyped-defs",
-        "--disallow-incomplete-defs",
+        "--strict",
         "--disallow-any-explicit",
-        "--disallow-any-generics",
         "src/",
     )
 

--- a/src/{{project_name}}/__init__.py
+++ b/src/{{project_name}}/__init__.py
@@ -1,3 +1,5 @@
+"""The {{project_name}} package."""
+
 import importlib.metadata
 
 __version__ = importlib.metadata.version(__name__)

--- a/src/{{project_name}}/tests/__init__.py
+++ b/src/{{project_name}}/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for {{project_name}}."""

--- a/src/{{project_name}}/tests/test_init.py
+++ b/src/{{project_name}}/tests/test_init.py
@@ -1,3 +1,5 @@
+"""Smoke tests for the {{project_name}} package."""
+
 import unittest
 from hamcrest import assert_that, contains_string
 
@@ -5,5 +7,8 @@ from .. import __version__
 
 
 class TestInit(unittest.TestCase):
-    def test_version(self):
+    """Check that package-level attributes are wired up."""
+
+    def test_version(self) -> None:
+        """The package exposes a dotted version string."""
         assert_that(__version__, contains_string("."))


### PR DESCRIPTION
- Target Python 3.12, 3.13, 3.14 in noxfile and PR workflow matrix
- Lint with stolid (python -m stolid) instead of flake8 directly
- Steal stolid's PyPI release tooling: dry_release nox session that
  validates builds against the pinned publish action, refreshed
  release.yml (upload/download-artifact v4, pinned pypi-publish v1.14.0)
- Align mypy session with stolid (--strict --disallow-any-explicit)
- Add docstrings to template sources so generated projects pass stolid