### PR TITLE
Add --upgrade flag to pip-compile in refresh_deps task

### DIFF
--- a/noxfile.py.jinja
+++ b/noxfile.py.jinja
@@ -158,6 +158,7 @@ def refresh_deps(session):
     for deps in ["tests", "docs", "lint", "mypy"]:
         session.run(
             "pip-compile",
+            "--upgrade",
             "--extra",
             deps,
             "pyproject.toml",


### PR DESCRIPTION
## Summary
Updated the `refresh_deps` nox session to include the `--upgrade` flag when running `pip-compile`, ensuring that dependency versions are upgraded to their latest available versions during the refresh process.

## Changes
- Added `--upgrade` flag to the `pip-compile` command in the `refresh_deps` session
- This flag applies to all dependency groups: tests, docs, lint, and mypy

## Details
The `--upgrade` flag instructs `pip-compile` to upgrade all dependencies to their latest compatible versions, rather than preserving existing pinned versions. This ensures that the dependency refresh process actively updates packages to newer releases when available.

https://claude.ai/code/session_01FKhmEJY8h8Rr9FM9ekXtGt